### PR TITLE
Fix staircase lighting normals

### DIFF
--- a/demo-project/scripts/stairs.gd
+++ b/demo-project/scripts/stairs.gd
@@ -164,6 +164,7 @@ func force_update_mesh() -> void:
 	var st = SurfaceTool.new()
 	st.begin(Mesh.PRIMITIVE_TRIANGLES)
 	st.set_material(mat)
+	st.set_smooth_group(-1)
 	for idx in vertices.size():
 		st.set_color(mat.albedo_color)
 		st.set_uv(uvs[idx])


### PR DESCRIPTION
Fixes incorrect lighting on generated stair meshes by forcing flat normals before generating normals.

Fixes #57  

<img width="975" height="770" alt="image" src="https://github.com/user-attachments/assets/76b55f29-e146-4ce2-bddb-3d10ca4dec02" />
